### PR TITLE
Need to pass our template loading through template_include

### DIFF
--- a/includes/class-wmd-member-directory.php
+++ b/includes/class-wmd-member-directory.php
@@ -21,7 +21,7 @@ class WMD_Member_Directory {
 	 * Run our actions
 	 */
 	public function __construct() {
-		add_action( 'template_include', array( __CLASS__, 'template_include' ) );
+		add_filter( 'template_include', array( __CLASS__, 'template_include' ) );
 		add_filter( 'cmb_meta_boxes',   array( __CLASS__, 'add_meta_boxes' ) );
 	}
 


### PR DESCRIPTION
Instead of using template_redirect we should utilize template_include as it does some odd things for us. For example, it will natively load the archive.php found in the theme AND load in our template in the plugin. template_include will load only our template we requested.
